### PR TITLE
Update install_generator.rb

### DIFF
--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -8,7 +8,7 @@ module Spina
     end
 
     def add_route
-      return if Rails.application.routes.routes.detect { |route| route.app.app == Spina::Engine }
+      return if Rails.application.routes.routes.detect { |route| route.app == Spina::Engine }
       route "mount Spina::Engine => '/'"
     end
 


### PR DESCRIPTION
Fixing error while installing Spina

create  config/initializers/spina.rb
C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/spina-0.8.1/lib/generators/spina/install_generator.rb:11:in `block in add_route': undefined method`app' for #Sprockets::Environment:0x62f36e8 (NoMethodError)
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/journey/routes.rb:28:in `each'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/journey/routes.rb:28:in`each'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/spina-0.8.1/lib/generators/spina/install_generator.rb:11:in `detect'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/spina-0.8.1/lib/generators/spina/install_generator.rb:11:in`add_route'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in`invoke_command'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in`each'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in`invoke_all'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in`start'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/generators.rb:157:in `invoke'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/commands/generate.rb:11:in`<top (required)>'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in`block in require'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:232:in `load_dependency'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in`require'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:135:in `generate_or_destroy'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:51:in`generate'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
        from C:/RailsInstaller/Ruby2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.8/lib/rails/commands.rb:17:in`<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in`<main>'
